### PR TITLE
Introducing "file" events

### DIFF
--- a/lib/sink.js
+++ b/lib/sink.js
@@ -6,59 +6,75 @@ const stream = require('readable-stream');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 
 
-module.exports = class SinkFs {
-    constructor (fileDir) {
-        assert(fileDir, '"fileDir" is missing');
-        this.fileDir = fileDir;
-    }
+class WriteStream extends stream.PassThrough {
+    constructor (options = {}, type) {
+        super();
 
-    writer (fileType, callback) {
-        const temp = path.join(this.fileDir, common.createTemporaryFilename(fileType));
-        const hasher = (fileType === 'json') ? new common.SourceHasher() : new common.FileHasher();
-        const parser = (fileType === 'json') ? JSONStream.parse('*') : new stream.PassThrough();
-        const proxy = new stream.PassThrough();
+        const temp = path.join(os.tmpdir(), common.createTemporaryFilename(type));
+        const hasher = (type === 'json') ? new common.SourceHasher() : new common.FileHasher();
+        const parser = (type === 'json') ? JSONStream.parse('*') : new stream.PassThrough();
 
         const file = fs.createWriteStream(temp);
         file.on('finish', () => {
             const id = hasher.hash;
-            const fileName = `${id}.${fileType}`;
-            fs.rename(temp, path.join(this.fileDir, fileName), () => {
-                if (callback) {
-                    callback(id, fileName);
+            const file = `${id}.${type}`;
+            fs.rename(temp, path.join(options.path, file), (error) => {
+                if (error) {
+                    return this.emit('file not saved');
                 }
+                this.emit('file saved', id, file);
             });
         });
 
-        file.on('error', (error) => {
-            console.log(error);
+        hasher.on('error', (error) => {
+            this.emit('error', error);
         });
 
-        proxy.pipe(parser).pipe(hasher);
-        proxy.pipe(file);
+        parser.on('error', (error) => {
+            this.emit('error', error);
+        });
 
-        return proxy;
+        file.on('error', (error) => {
+            this.emit('error', error);
+        });
+
+        this.pipe(parser).pipe(hasher);
+        this.pipe(file);
+    }
+}
+
+
+class ReadStream extends fs.createReadStream {
+    constructor (...args) {
+        super(...args);
+        this.on('open', () => {
+            this.emit('file found');
+        });
+        this.on('error', (error) => {
+            if (error.code === 'ENOENT') {
+                this.emit('file not found');
+            }
+        });
+    }
+}
+
+
+module.exports = class SinkFs {
+    constructor (options = {}) {
+        assert(options.path, '"options.path" is missing');
+        this.options = Object.assign({}, options);
     }
 
-    reader (fileName) {
-        assert(fileName, '"fileName" is missing');
-        const from = path.join(this.fileDir, fileName);
+    writer (type) {
+        assert(type, '"type" is missing');
+        return new WriteStream(this.options, type);
+    }
 
-        class ReadStream extends fs.createReadStream {
-            constructor (...args) {
-                super(...args);
-                this.on('open', () => {
-                    this.emit('file found');
-                });
-                this.on('error', (error) => {
-                    if (error.code === 'ENOENT') {
-                        this.emit('file not found', error);
-                    }
-                });
-            }
-        }
-
-        return new ReadStream(from);
+    reader (file) {
+        assert(file, '"file" is missing');
+        return new ReadStream(path.join(this.options.path, file));
     }
 };

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -8,52 +8,57 @@ const path = require('path');
 const fs = require('fs');
 
 
-const SinkFs = module.exports = function (fileDir) {
-    if (!(this instanceof SinkFs)) { return new SinkFs(fileDir); }
-    assert(fileDir, '"fileDir" must be provided');
+module.exports = class SinkFs {
+    constructor (fileDir) {
+        assert(fileDir, '"fileDir" is missing');
+        this.fileDir = fileDir;
+    }
 
-    this.fileDir = fileDir;
-};
+    writer (fileType, callback) {
+        const temp = path.join(this.fileDir, common.createTemporaryFilename(fileType));
+        const hasher = (fileType === 'json') ? new common.SourceHasher() : new common.FileHasher();
+        const parser = (fileType === 'json') ? JSONStream.parse('*') : new stream.PassThrough();
+        const proxy = new stream.PassThrough();
 
-
-SinkFs.prototype.writer = function (fileType, callback) {
-    const temp = path.join(this.fileDir, common.createTemporaryFilename(fileType));
-    const hasher = (fileType === 'json') ? new common.SourceHasher() : new common.FileHasher();
-    const parser = (fileType === 'json') ? JSONStream.parse('*') : new stream.PassThrough();
-    const proxy = new stream.PassThrough();
-
-
-    const file = fs.createWriteStream(temp);
-    file.on('finish', () => {
-        const id = hasher.hash;
-        const fileName = `${id}.${fileType}`;
-        fs.rename(temp, path.join(this.fileDir, fileName), () => {
-            if (callback) {
-                callback(id, fileName);
-            }
+        const file = fs.createWriteStream(temp);
+        file.on('finish', () => {
+            const id = hasher.hash;
+            const fileName = `${id}.${fileType}`;
+            fs.rename(temp, path.join(this.fileDir, fileName), () => {
+                if (callback) {
+                    callback(id, fileName);
+                }
+            });
         });
-    });
 
-    file.on('error', (error) => {
-        console.log(error);
-    });
+        file.on('error', (error) => {
+            console.log(error);
+        });
 
-    proxy.pipe(parser).pipe(hasher);
-    proxy.pipe(file);
+        proxy.pipe(parser).pipe(hasher);
+        proxy.pipe(file);
 
-    return proxy;
-};
+        return proxy;
+    }
 
+    reader (fileName) {
+        assert(fileName, '"fileName" is missing');
+        const from = path.join(this.fileDir, fileName);
 
-SinkFs.prototype.reader = function (fileName, callback) {
-    const from = this.fileDir + fileName;
-    const file = fs.createReadStream(from);
-
-    file.on('finish', () => {
-        if (callback) {
-            callback();
+        class ReadStream extends fs.createReadStream {
+            constructor (...args) {
+                super(...args);
+                this.on('open', () => {
+                    this.emit('file found');
+                });
+                this.on('error', (error) => {
+                    if (error.code === 'ENOENT') {
+                        this.emit('file not found', error);
+                    }
+                });
+            }
         }
-    });
 
-    return file;
+        return new ReadStream(from);
+    }
 };

--- a/lib/sink.js
+++ b/lib/sink.js
@@ -17,8 +17,8 @@ class WriteStream extends stream.PassThrough {
         const hasher = (type === 'json') ? new common.SourceHasher() : new common.FileHasher();
         const parser = (type === 'json') ? JSONStream.parse('*') : new stream.PassThrough();
 
-        const file = fs.createWriteStream(temp);
-        file.on('finish', () => {
+        const fileStream = fs.createWriteStream(temp);
+        fileStream.on('finish', () => {
             const id = hasher.hash;
             const file = `${id}.${type}`;
             fs.rename(temp, path.join(options.path, file), (error) => {
@@ -37,12 +37,12 @@ class WriteStream extends stream.PassThrough {
             this.emit('error', error);
         });
 
-        file.on('error', (error) => {
+        fileStream.on('error', (error) => {
             this.emit('error', error);
         });
 
         this.pipe(parser).pipe(hasher);
-        this.pipe(file);
+        this.pipe(fileStream);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "tap test/*.js"
+    "test": "tap --jobs=4 test/*.js"
   },
   "files": [
     "lib"

--- a/test/sink.js
+++ b/test/sink.js
@@ -3,31 +3,90 @@
 const stream = require('readable-stream');
 const Sink = require('../');
 const tap = require('tap');
+const fs = require('fs');
+const os = require('os');
 
 
-tap.test('constructor() - no value for "fileDir" argument - should throw', (t) => {
+tap.test('constructor() - no value for "options.path" argument - should throw', (t) => {
     t.throws(() => {
         new Sink(); // eslint-disable-line
-    }, new Error('"fileDir" is missing'));
+    }, new Error('"options.path" is missing'));
     t.end();
 });
 
-tap.test('constructor() - has value for "fileDir" argument - should be of Sink Class type', (t) => {
-    t.type(new Sink('./'), Sink);
+tap.test('constructor() - has value for "options.path" argument - should be of Sink Class type', (t) => {
+    t.type(new Sink({
+        path: './',
+    }), Sink);
     t.end();
 });
 
 
-tap.test('.reader() - no value for "fileName" argument - should throw', (t) => {
-    const sink = new Sink('./test/mock/');
+tap.test('.writer() - no value for "type" argument - should throw', (t) => {
+    const sink = new Sink({
+        path: './test/.tmp/',
+    });
+    t.throws(() => {
+        const dest = sink.writer(); // eslint-disable-line
+    }, new Error('"type" is missing'));
+    t.end();
+});
+
+tap.test('.writer() - save to non existing path - should emit "file not saved" event', (t) => {
+    const sink = new Sink({
+        path: './test/.nonExistingDirectory/',
+    });
+    const source = fs.createReadStream('./test/mock/feed.a.json');
+    const dest = sink.writer('json');
+    dest.on('file not saved', () => {
+        t.assert(true);
+        t.end();
+    });
+    source.pipe(dest);
+});
+
+tap.test('.writer() - save to existing path - should emit "file saved" event', (t) => {
+    const sink = new Sink({
+        path: os.tmpdir(),
+    });
+    const source = fs.createReadStream('./test/mock/feed.a.json');
+    const dest = sink.writer('json');
+    dest.on('file saved', () => {
+        t.assert(true);
+        t.end();
+    });
+    source.pipe(dest);
+});
+
+tap.test('.writer() - on "file saved" - should have "id" and "file" on emitted event', (t) => {
+    const sink = new Sink({
+        path: os.tmpdir(),
+    });
+    const source = fs.createReadStream('./test/mock/feed.a.json');
+    const dest = sink.writer('json');
+    dest.on('file saved', (id, file) => {
+        t.assert(id);
+        t.assert(file);
+        t.end();
+    });
+    source.pipe(dest);
+});
+
+
+tap.test('.reader() - no value for "file" argument - should throw', (t) => {
+    const sink = new Sink({
+        path: './test/mock/',
+    });
     t.throws(() => {
         const source = sink.reader(); // eslint-disable-line
-    }, new Error('"fileName" is missing'));
+    }, new Error('"file" is missing'));
     t.end();
 });
 
 tap.test('.reader() - read non-existing file - should emit "file not found" event', (t) => {
-    const sink = new Sink('./test/mock/');
+    const sink = new Sink({
+        path: './test/mock/',
+    });
     const source = sink.reader('feed.b.json');
     source.on('file not found', () => {
         t.assert(true);
@@ -36,7 +95,9 @@ tap.test('.reader() - read non-existing file - should emit "file not found" even
 });
 
 tap.test('.reader() - read non-existing file - should emit (inherited) "error" event', (t) => {
-    const sink = new Sink('./test/mock/');
+    const sink = new Sink({
+        path: './test/mock/',
+    });
     const source = sink.reader('feed.b.json');
     source.on('error', () => {
         t.assert(true);
@@ -45,7 +106,9 @@ tap.test('.reader() - read non-existing file - should emit (inherited) "error" e
 });
 
 tap.test('.reader() - read existing file - should emit "file found" event', (t) => {
-    const sink = new Sink('./test/mock/');
+    const sink = new Sink({
+        path: './test/mock/',
+    });
     const source = sink.reader('feed.a.json');
     source.on('file found', () => {
         t.assert(true);
@@ -54,7 +117,9 @@ tap.test('.reader() - read existing file - should emit "file found" event', (t) 
 });
 
 tap.test('.reader() - read existing file - should emit (inherited) "open" event', (t) => {
-    const sink = new Sink('./test/mock/');
+    const sink = new Sink({
+        path: './test/mock/',
+    });
     const source = sink.reader('feed.a.json');
     source.on('open', () => {
         t.assert(true);
@@ -63,7 +128,9 @@ tap.test('.reader() - read existing file - should emit (inherited) "open" event'
 });
 
 tap.test('.reader() - read existing file - should emit (inherited) "open" event', (t) => {
-    const sink = new Sink('./test/mock/');
+    const sink = new Sink({
+        path: './test/mock/',
+    });
     const source = sink.reader('feed.a.json');
     source.on('open', () => {
         t.assert(true);
@@ -80,7 +147,9 @@ tap.test('.reader() - read existing file - should stream read file', (t) => {
         },
     });
 
-    const sink = new Sink('./test/mock/');
+    const sink = new Sink({
+        path: './test/mock/',
+    });
     const source = sink.reader('feed.a.json');
 
     source.on('file found', () => {

--- a/test/sink.js
+++ b/test/sink.js
@@ -1,28 +1,94 @@
 'use strict';
 
+const stream = require('readable-stream');
 const Sink = require('../');
 const tap = require('tap');
-const fs = require('fs');
-const { tmpdir } = require('os');
 
 
-tap.test('not a real test', (t) => {
-    const sink = new Sink(tmpdir());
-    const file = fs.createReadStream('./test/mock/feed.a.json');
-    const dest = sink.writer('json', (filename) => {
-        console.log(filename);
-        t.end();
-    });
-    file.pipe(dest);
+tap.test('constructor() - no value for "fileDir" argument - should throw', (t) => {
+    t.throws(() => {
+        new Sink(); // eslint-disable-line
+    }, new Error('"fileDir" is missing'));
+    t.end();
+});
+
+tap.test('constructor() - has value for "fileDir" argument - should be of Sink Class type', (t) => {
+    t.type(new Sink('./'), Sink);
+    t.end();
 });
 
 
-tap.test('another not a real test', (t) => {
-    const sink = new Sink(tmpdir());
-    const file = fs.createReadStream('./test/mock/feed.a.json');
-    const dest = sink.writer('js', (filename) => {
-        console.log(filename);
+tap.test('.reader() - no value for "fileName" argument - should throw', (t) => {
+    const sink = new Sink('./test/mock/');
+    t.throws(() => {
+        const source = sink.reader(); // eslint-disable-line
+    }, new Error('"fileName" is missing'));
+    t.end();
+});
+
+tap.test('.reader() - read non-existing file - should emit "file not found" event', (t) => {
+    const sink = new Sink('./test/mock/');
+    const source = sink.reader('feed.b.json');
+    source.on('file not found', () => {
+        t.assert(true);
         t.end();
     });
-    file.pipe(dest);
+});
+
+tap.test('.reader() - read non-existing file - should emit (inherited) "error" event', (t) => {
+    const sink = new Sink('./test/mock/');
+    const source = sink.reader('feed.b.json');
+    source.on('error', () => {
+        t.assert(true);
+        t.end();
+    });
+});
+
+tap.test('.reader() - read existing file - should emit "file found" event', (t) => {
+    const sink = new Sink('./test/mock/');
+    const source = sink.reader('feed.a.json');
+    source.on('file found', () => {
+        t.assert(true);
+        t.end();
+    });
+});
+
+tap.test('.reader() - read existing file - should emit (inherited) "open" event', (t) => {
+    const sink = new Sink('./test/mock/');
+    const source = sink.reader('feed.a.json');
+    source.on('open', () => {
+        t.assert(true);
+        t.end();
+    });
+});
+
+tap.test('.reader() - read existing file - should emit (inherited) "open" event', (t) => {
+    const sink = new Sink('./test/mock/');
+    const source = sink.reader('feed.a.json');
+    source.on('open', () => {
+        t.assert(true);
+        t.end();
+    });
+});
+
+tap.test('.reader() - read existing file - should stream read file', (t) => {
+    const dest = new stream.Writable({
+        _data: false,
+        write (chunk, encoding, next) {
+            this._data += chunk;
+            next();
+        },
+    });
+
+    const sink = new Sink('./test/mock/');
+    const source = sink.reader('feed.a.json');
+
+    source.on('file found', () => {
+        source.pipe(dest);
+    });
+
+    dest.on('finish', () => {
+        t.assert(dest._data);
+        t.end();
+    });
 });


### PR DESCRIPTION
The main idea behind [the](https://github.com/asset-pipe/asset-pipe-sink-s3) [sinks](https://github.com/asset-pipe/asset-pipe-sink-mem) in this project is to provide a common way to plug in different storage types in the [asset-pipe-build-server](https://github.com/asset-pipe/asset-pipe-build-server). Iow, the sinks are intended to provide a common interface that bridge http io in the asset-pipe-build-server to what ever back-end storage we want to support.

The interface as is must be a class that must have a `writer()` method which returns a `WritableStream` and a `reader()` method which returns a `ReadableStream`.

In its simplest form, this makes it possible for us to ex use this sink for writing and reading to the file system as follow in the asset-pipe-build-server when running in development:

```js
const app = express();
const sink = new SinkFs('./someDir');
app.get('/feed/:file', (req, res, next) => {
    const reader = sink.reader(req.params.file);
    reader.pipe(res);
});
```

And then replace the sink with ex [something that writes and reads to Amazon S3](https://github.com/asset-pipe/asset-pipe-sink-s3) in production:

```js
const app = express();
const sink = new SinkS3({s3:'config stuff'});
app.get('/feed/:file', (req, res, next) => {
    const reader = sink.reader(req.params.file);
    reader.pipe(res);
});
```

The above `.pipe()` is very naive and won't really fly in production. Inside the asset-pipe-build-server we need something stronger and we need to handle sending proper http status codes etc. This PR introduces the concept of "file events" in the interface of the sinks. Iow; the sinks should emit a set of events telling us if files exist, does not exist etc.

The following events are introduces in the `.reader()` method:

 - `file found` - Emitted when the wanted file exist in the storage and are ready to be streamed.
 - `file not found` - Emitted when the wanted file does not exist in the storage.

With this we can write a more solid implementation in the asset-pipe-build-server:

```js
const app = express();
const sink = new SinkFs('./someDir');
app.get('/feed/:file', (req, res, next) => {
    const reader = sink.reader(req.params.file);
    reader.on('file not found', () => {
        res.status(404).send('File not found');
    });
    reader.on('file found', () => {
        res.writeHead(200, {});
        reader.pipe(res);
    });
});
```

Having a set of unified events like this is handy since each type of storage will provide info about files existence etc differently.

The question is also; which other events do we need?

This PR does also add proper tests of the `.reader()` method.